### PR TITLE
Add 'npm run license-checker' to package.json

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
                     testbed.inside(){
                       sh "npm install"
                       sh "npm audit"
+                      sh "npm run license-checker"
                     }
                   }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                   ws("${env.WORKSPACE}/${env.BUILD_NUMBER}") {
                     def testbed = docker.image('node:10')
                     testbed.inside(){
+                      sh "npm run license-checker"
                       sh "npm run build"
                       sh "npm run citest"
                     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e --proxy-config proxy.conf.json",
     "build": "ng build --prod --aot=true --source-map=false --build-optimizer=false",
-    "license-checker": "npx license-checker --summary --production --excludePackages 'gcr-web@0.0.1' --onlyAllow 'MIT;ISC;Apache-2.0;Apache 2.0;BSD;WTFPL;Artistic-2.0;CC0-1.0;CC-BY-3.0;Unlicense'"
+    "license-checker": "npx license-checker --summary --production --excludePackages 'angular-boilerplate@0.0.0' --onlyAllow 'MIT;ISC;Apache-2.0;Apache 2.0;BSD;WTFPL;Artistic-2.0;CC0-1.0;CC-BY-3.0;Unlicense;Public Domain;'"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "citest": "ng test --watch=false",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e --proxy-config proxy.conf.json",
-    "build": "ng build --prod --aot=true --source-map=false --build-optimizer=false"
+    "build": "ng build --prod --aot=true --source-map=false --build-optimizer=false",
+    "license-checker": "npx license-checker --summary --production --excludePackages 'angular-boilerplate@0.0.0' --onlyAllow 'MIT;ISC;Apache-2.0;BSD;WTFPL'"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e --proxy-config proxy.conf.json",
     "build": "ng build --prod --aot=true --source-map=false --build-optimizer=false",
-    "license-checker": "npx license-checker --summary --production --excludePackages 'angular-boilerplate@0.0.0' --onlyAllow 'MIT;ISC;Apache-2.0;BSD;WTFPL'"
+    "license-checker": "npx license-checker --summary --production --excludePackages 'gcr-web@0.0.1' --onlyAllow 'MIT;ISC;Apache-2.0;Apache 2.0;BSD;WTFPL;Artistic-2.0;CC0-1.0;CC-BY-3.0;Unlicense'"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
We do not want to accidentally use a package that requires a license.

Since this package is private, it has to be ignored, or it will result in 'UNLICENSED' which will cause the check to fail.