### PR TITLE
Replace npm install with npm ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     checkout scm
                     def testbed = docker.image('node:10')
                     testbed.inside(){
-                      sh "npm install"
+                      sh "npm ci"
                       sh "npm audit"
                       sh "npm run license-checker"
                     }


### PR DESCRIPTION
`npm ci` should result in quicker builds, and utilizes package-lock

REF: https://hackernoon.com/how-to-speed-up-continuous-integration-build-with-new-npm-ci-and-package-lock-json-7647f91751a